### PR TITLE
Fix text extraction and writing issues

### DIFF
--- a/src/podofo/main/PdfColor.cpp
+++ b/src/podofo/main/PdfColor.cpp
@@ -683,7 +683,7 @@ PdfColor PdfColor::FromString(const string_view& name)
     if (isdigit(name[0]) || name[0] == '.')
     {
         double grayVal = 0.0;
-        if (std::from_chars(name.data() + 1, name.data() + name.size(), grayVal, chars_format::fixed).ec != std::errc())
+        if (PODOFO_FROM_CHARS_DOUBLE(name.data() + 1, name.data() + name.size(), grayVal, chars_format::fixed).ec != std::errc())
             PODOFO_RAISE_ERROR_INFO(PdfErrorCode::NoNumber, "Could not read number");
 
         return PdfColor(grayVal);

--- a/src/podofo/main/PdfEncodingFactory.cpp
+++ b/src/podofo/main/PdfEncodingFactory.cpp
@@ -31,9 +31,13 @@ PdfEncoding PdfEncodingFactory::CreateEncoding(const PdfObject& fontObj, const P
     if (encodingObj != nullptr)
         encoding = createEncodingMap(*encodingObj, metrics);
 
+    bool usedImplicitEncoding = false;
     PdfEncodingMapConstPtr implicitEncoding;
     if (encoding == nullptr && metrics.TryGetImplicitEncoding(implicitEncoding))
+    {
         encoding = implicitEncoding;
+        usedImplicitEncoding = true;
+    }
 
     // TODO: Implement full text extraction, including search in predefined
     // CMap(s) as described in Pdf Reference and here https://stackoverflow.com/a/26910569/213871
@@ -67,6 +71,24 @@ PdfEncoding PdfEncodingFactory::CreateEncoding(const PdfObject& fontObj, const P
         {
             // As a fallback, create an identity encoding of the size size of the /ToUnicode mapping
             encoding = std::make_shared<PdfIdentityEncoding>(toUnicode->GetLimits().MaxCodeSize);
+        }
+    }
+
+    // When the encoding came from FreeType's implicit encoding (not from the
+    // PDF's /Encoding dictionary) and a /ToUnicode map is present, the implicit
+    // encoding's MaxCodeSize may be wrong. FreeType can report Type1 fonts as
+    // CMap-type with MaxCodeSize=2, but PDF Type1 fonts always use 1-byte
+    // character codes. If the code sizes disagree, trust the /ToUnicode map's
+    // code size since it directly corresponds to the content stream's encoding.
+    // This fix is NOT applied when /Encoding is explicitly specified in the PDF,
+    // which is authoritative (e.g., Type0/CID fonts with 2-byte codes).
+    if (usedImplicitEncoding && toUnicode != nullptr)
+    {
+        auto toUnicodeMaxCodeSize = toUnicode->GetLimits().MaxCodeSize;
+        auto encodingMaxCodeSize = encoding->GetLimits().MaxCodeSize;
+        if (toUnicodeMaxCodeSize != encodingMaxCodeSize)
+        {
+            encoding = std::make_shared<PdfIdentityEncoding>(toUnicodeMaxCodeSize);
         }
     }
 

--- a/src/podofo/main/PdfPage_TextExtraction.cpp
+++ b/src/podofo/main/PdfPage_TextExtraction.cpp
@@ -365,6 +365,14 @@ void PdfPage::ExtractTextTo(vector<PdfTextEntry>& entries, const string_view& pa
                         context.States.Current->PdfState.WordSpacing = content.Stack[0].GetReal();
                         break;
                     }
+                    // scale Tz : Set the horizontal scaling, T_h
+                    case PdfOperator::Tz:
+                    {
+                        // PDF spec: Tz operand is a percentage (e.g., 80 means 80%)
+                        // PdfTextState::FontScale is stored as a fraction (e.g., 0.8)
+                        context.States.Current->PdfState.FontScale = content.Stack[0].GetReal() / 100.0;
+                        break;
+                    }
                     // q : Save the current graphics state
                     case PdfOperator::q:
                     {

--- a/src/podofo/main/PdfPainter.cpp
+++ b/src/podofo/main/PdfPainter.cpp
@@ -1096,17 +1096,15 @@ void PdfPainter::writeTextState()
     if (textState.Font != nullptr)
         setFont(textState.Font, textState.FontSize);
 
-    if (textState.FontScale != 1)
-        setFontScale(textState.FontScale);
-
-    if (textState.CharSpacing != 0)
-        setCharSpacing(textState.CharSpacing);
-
-    if (textState.WordSpacing != 0)
-        setWordSpacing(textState.WordSpacing);
-
-    if (textState.RenderingMode != PdfTextRenderingMode::Fill)
-        setTextRenderingMode(textState.RenderingMode);
+    // NOTE: Always emit text state operators (Tz, Tc, Tw, Tr) even for
+    // default values. PDF text state persists across BT/ET blocks, so
+    // a previous block's non-default value would leak into the current
+    // block if we skip emitting the default. The set*() methods already
+    // optimize by checking EmittedTextState to avoid truly redundant writes.
+    setFontScale(textState.FontScale);
+    setCharSpacing(textState.CharSpacing);
+    setWordSpacing(textState.WordSpacing);
+    setTextRenderingMode(textState.RenderingMode);
 }
 
 void PdfPainter::addToPageResources(const PdfName& type, const PdfName& identifier, const PdfObject& obj)

--- a/src/podofo/main/PdfTokenizer.cpp
+++ b/src/podofo/main/PdfTokenizer.cpp
@@ -294,7 +294,7 @@ PdfTokenizer::PdfLiteralDataType PdfTokenizer::DetermineDataType(InputStreamDevi
             if (dataType == PdfLiteralDataType::Real)
             {
                 double val;
-                if (std::from_chars(token.data(), token.data() + token.length(), val, chars_format::fixed).ec != std::errc())
+                if (PODOFO_FROM_CHARS_DOUBLE(token.data(), token.data() + token.length(), val, chars_format::fixed).ec != std::errc())
                 {
                     // Don't consume the token
                     this->EnqueueToken(token, tokenType);

--- a/src/podofo/private/XmlUtils.h
+++ b/src/podofo/private/XmlUtils.h
@@ -16,7 +16,7 @@
 
 #define THROW_LIBXML_EXCEPTION(msg)\
 {\
-    xmlErrorPtr error_ = xmlGetLastError();\
+    const xmlError* error_ = xmlGetLastError();\
     if (error_ == nullptr)\
         PODOFO_RAISE_ERROR_INFO(PdfErrorCode::XmpMetadata, msg);\
     else\

--- a/src/podofo/private/charconv_compat.h
+++ b/src/podofo/private/charconv_compat.h
@@ -7,11 +7,17 @@
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 10
 #define WANT_CHARS_FORMAT
 #endif
-#if (defined(__GNUC__) && __GNUC__ < 11) || defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 11
 #define WANT_FROM_CHARS
 #endif
+// On Apple Clang, std::from_chars for double may be declared but
+// unavailable for the deployment target, causing ambiguity.
+// Use fast_float wrapper via a distinct namespace to avoid conflicts.
+#if defined(__clang__)
+#define WANT_FROM_CHARS_COMPAT
+#endif
 
-#if defined(WANT_CHARS_FORMAT) || defined(WANT_FROM_CHARS)
+#if defined(WANT_CHARS_FORMAT) || defined(WANT_FROM_CHARS) || defined(WANT_FROM_CHARS_COMPAT)
 #include <fast_float.h>
 #endif
 
@@ -40,5 +46,28 @@ namespace std
 }
 
 #endif // WANT_FROM_CHARS
+
+#ifdef WANT_FROM_CHARS_COMPAT
+
+namespace podofo_compat
+{
+    inline std::from_chars_result from_chars(const char* first, const char* last,
+        double& value, std::chars_format fmt) noexcept
+    {
+        auto ret = fast_float::from_chars(first, last, value, (fast_float::chars_format)fmt);
+        return { ret.ptr, ret.ec };
+    }
+}
+
+// Override std::from_chars for double with the compat version
+#define PODOFO_FROM_CHARS_DOUBLE(first, last, value, fmt) \
+    podofo_compat::from_chars(first, last, value, fmt)
+
+#else
+
+#define PODOFO_FROM_CHARS_DOUBLE(first, last, value, fmt) \
+    std::from_chars(first, last, value, fmt)
+
+#endif // WANT_FROM_CHARS_COMPAT
 
 #endif // CHARCONV_COMPAT_H


### PR DESCRIPTION
- PdfPage_TextExtraction: Handle Tz operator to correctly extract FontScale
- PdfPainter: Always emit text state (Tz/Tc/Tw/Tr) in writeTextState() to prevent state leakage across BT/ET blocks
- PdfEncodingFactory: Fix implicit encoding MaxCodeSize mismatch with ToUnicode map for Type1 fonts (FreeType reports CMap with MaxCodeSize=2 but PDF Type1 fonts use 1-byte codes)
- charconv_compat: Fix from_chars ambiguity on Apple Clang 17+
- PdfColor/PdfTokenizer: Use PODOFO_FROM_CHARS_DOUBLE macro