### PR TITLE
Add AES-256 (AESV3/R6) decryption support without libidn

### DIFF
--- a/src/podofo/auxiliary/SHA.h
+++ b/src/podofo/auxiliary/SHA.h
@@ -1,0 +1,286 @@
+/*
+ * SHA-256, SHA-384, SHA-512 implementation
+ * Based on FIPS 180-4 (Secure Hash Standard)
+ *
+ * This is a standalone implementation with no external dependencies.
+ */
+
+#ifndef _PODOFO_SHA_H_
+#define _PODOFO_SHA_H_
+
+#include <cstdint>
+#include <cstring>
+
+// SHA-256
+
+class SHA256 {
+public:
+    static constexpr unsigned DIGEST_SIZE = 32;
+    static constexpr unsigned BLOCK_SIZE = 64;
+
+    SHA256() { reset(); }
+
+    void reset() {
+        m_totalLen = 0;
+        m_bufLen = 0;
+        m_h[0] = 0x6a09e667; m_h[1] = 0xbb67ae85;
+        m_h[2] = 0x3c6ef372; m_h[3] = 0xa54ff53a;
+        m_h[4] = 0x510e527f; m_h[5] = 0x9b05688c;
+        m_h[6] = 0x1f83d9ab; m_h[7] = 0x5be0cd19;
+    }
+
+    void update(const unsigned char* data, size_t len) {
+        m_totalLen += len;
+        while (len > 0) {
+            size_t toCopy = BLOCK_SIZE - m_bufLen;
+            if (toCopy > len) toCopy = len;
+            std::memcpy(m_buf + m_bufLen, data, toCopy);
+            m_bufLen += toCopy;
+            data += toCopy;
+            len -= toCopy;
+            if (m_bufLen == BLOCK_SIZE) {
+                processBlock(m_buf);
+                m_bufLen = 0;
+            }
+        }
+    }
+
+    void final(unsigned char digest[DIGEST_SIZE]) {
+        uint64_t totalBits = m_totalLen * 8;
+        unsigned char pad = 0x80;
+        update(&pad, 1);
+        pad = 0;
+        while (m_bufLen != 56)
+            update(&pad, 1);
+        unsigned char lenBytes[8];
+        for (int i = 7; i >= 0; i--) {
+            lenBytes[i] = (unsigned char)(totalBits & 0xff);
+            totalBits >>= 8;
+        }
+        update(lenBytes, 8);
+        for (int i = 0; i < 8; i++) {
+            digest[i*4+0] = (unsigned char)(m_h[i] >> 24);
+            digest[i*4+1] = (unsigned char)(m_h[i] >> 16);
+            digest[i*4+2] = (unsigned char)(m_h[i] >> 8);
+            digest[i*4+3] = (unsigned char)(m_h[i]);
+        }
+    }
+
+    static void hash(const unsigned char* data, size_t len, unsigned char digest[DIGEST_SIZE]) {
+        SHA256 ctx;
+        ctx.update(data, len);
+        ctx.final(digest);
+    }
+
+private:
+    static uint32_t rotr(uint32_t x, int n) { return (x >> n) | (x << (32 - n)); }
+    static uint32_t Ch(uint32_t x, uint32_t y, uint32_t z) { return (x & y) ^ (~x & z); }
+    static uint32_t Maj(uint32_t x, uint32_t y, uint32_t z) { return (x & y) ^ (x & z) ^ (y & z); }
+    static uint32_t Sigma0(uint32_t x) { return rotr(x,2) ^ rotr(x,13) ^ rotr(x,22); }
+    static uint32_t Sigma1(uint32_t x) { return rotr(x,6) ^ rotr(x,11) ^ rotr(x,25); }
+    static uint32_t sigma0(uint32_t x) { return rotr(x,7) ^ rotr(x,18) ^ (x >> 3); }
+    static uint32_t sigma1(uint32_t x) { return rotr(x,17) ^ rotr(x,19) ^ (x >> 10); }
+
+    void processBlock(const unsigned char block[BLOCK_SIZE]) {
+        static const uint32_t K[64] = {
+            0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
+            0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
+            0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
+            0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
+            0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
+            0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
+            0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
+            0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+        };
+        uint32_t w[64];
+        for (int i = 0; i < 16; i++)
+            w[i] = ((uint32_t)block[i*4]<<24) | ((uint32_t)block[i*4+1]<<16) |
+                   ((uint32_t)block[i*4+2]<<8) | (uint32_t)block[i*4+3];
+        for (int i = 16; i < 64; i++)
+            w[i] = sigma1(w[i-2]) + w[i-7] + sigma0(w[i-15]) + w[i-16];
+
+        uint32_t a=m_h[0], b=m_h[1], c=m_h[2], d=m_h[3];
+        uint32_t e=m_h[4], f=m_h[5], g=m_h[6], h=m_h[7];
+        for (int i = 0; i < 64; i++) {
+            uint32_t t1 = h + Sigma1(e) + Ch(e,f,g) + K[i] + w[i];
+            uint32_t t2 = Sigma0(a) + Maj(a,b,c);
+            h=g; g=f; f=e; e=d+t1; d=c; c=b; b=a; a=t1+t2;
+        }
+        m_h[0]+=a; m_h[1]+=b; m_h[2]+=c; m_h[3]+=d;
+        m_h[4]+=e; m_h[5]+=f; m_h[6]+=g; m_h[7]+=h;
+    }
+
+    uint32_t m_h[8];
+    unsigned char m_buf[BLOCK_SIZE];
+    size_t m_bufLen;
+    uint64_t m_totalLen;
+};
+
+// SHA-512 (also used as base for SHA-384)
+
+class SHA512Base {
+public:
+    static constexpr unsigned BLOCK_SIZE = 128;
+
+    void update(const unsigned char* data, size_t len) {
+        m_totalLen += len;
+        while (len > 0) {
+            size_t toCopy = BLOCK_SIZE - m_bufLen;
+            if (toCopy > len) toCopy = len;
+            std::memcpy(m_buf + m_bufLen, data, toCopy);
+            m_bufLen += toCopy;
+            data += toCopy;
+            len -= toCopy;
+            if (m_bufLen == BLOCK_SIZE) {
+                processBlock(m_buf);
+                m_bufLen = 0;
+            }
+        }
+    }
+
+protected:
+    void initState(const uint64_t iv[8]) {
+        m_totalLen = 0;
+        m_bufLen = 0;
+        std::memcpy(m_h, iv, sizeof(m_h));
+    }
+
+    void finalImpl(unsigned char* digest, unsigned digestLen) {
+        uint64_t totalBits = m_totalLen * 8;
+        unsigned char pad = 0x80;
+        update(&pad, 1);
+        pad = 0;
+        while (m_bufLen != 112)
+            update(&pad, 1);
+        unsigned char lenBytes[16];
+        std::memset(lenBytes, 0, 8); // high 64 bits = 0
+        for (int i = 15; i >= 8; i--) {
+            lenBytes[i] = (unsigned char)(totalBits & 0xff);
+            totalBits >>= 8;
+        }
+        update(lenBytes, 16);
+        for (unsigned i = 0; i < digestLen / 8; i++) {
+            digest[i*8+0] = (unsigned char)(m_h[i] >> 56);
+            digest[i*8+1] = (unsigned char)(m_h[i] >> 48);
+            digest[i*8+2] = (unsigned char)(m_h[i] >> 40);
+            digest[i*8+3] = (unsigned char)(m_h[i] >> 32);
+            digest[i*8+4] = (unsigned char)(m_h[i] >> 24);
+            digest[i*8+5] = (unsigned char)(m_h[i] >> 16);
+            digest[i*8+6] = (unsigned char)(m_h[i] >> 8);
+            digest[i*8+7] = (unsigned char)(m_h[i]);
+        }
+    }
+
+private:
+    static uint64_t rotr(uint64_t x, int n) { return (x >> n) | (x << (64 - n)); }
+    static uint64_t Ch(uint64_t x, uint64_t y, uint64_t z) { return (x & y) ^ (~x & z); }
+    static uint64_t Maj(uint64_t x, uint64_t y, uint64_t z) { return (x & y) ^ (x & z) ^ (y & z); }
+    static uint64_t Sigma0(uint64_t x) { return rotr(x,28) ^ rotr(x,34) ^ rotr(x,39); }
+    static uint64_t Sigma1(uint64_t x) { return rotr(x,14) ^ rotr(x,18) ^ rotr(x,41); }
+    static uint64_t sigma0(uint64_t x) { return rotr(x,1) ^ rotr(x,8) ^ (x >> 7); }
+    static uint64_t sigma1(uint64_t x) { return rotr(x,19) ^ rotr(x,61) ^ (x >> 6); }
+
+    void processBlock(const unsigned char block[BLOCK_SIZE]) {
+        static const uint64_t K[80] = {
+            0x428a2f98d728ae22ULL,0x7137449123ef65cdULL,0xb5c0fbcfec4d3b2fULL,0xe9b5dba58189dbbcULL,
+            0x3956c25bf348b538ULL,0x59f111f1b605d019ULL,0x923f82a4af194f9bULL,0xab1c5ed5da6d8118ULL,
+            0xd807aa98a3030242ULL,0x12835b0145706fbeULL,0x243185be4ee4b28cULL,0x550c7dc3d5ffb4e2ULL,
+            0x72be5d74f27b896fULL,0x80deb1fe3b1696b1ULL,0x9bdc06a725c71235ULL,0xc19bf174cf692694ULL,
+            0xe49b69c19ef14ad2ULL,0xefbe4786384f25e3ULL,0x0fc19dc68b8cd5b5ULL,0x240ca1cc77ac9c65ULL,
+            0x2de92c6f592b0275ULL,0x4a7484aa6ea6e483ULL,0x5cb0a9dcbd41fbd4ULL,0x76f988da831153b5ULL,
+            0x983e5152ee66dfabULL,0xa831c66d2db43210ULL,0xb00327c898fb213fULL,0xbf597fc7beef0ee4ULL,
+            0xc6e00bf33da88fc2ULL,0xd5a79147930aa725ULL,0x06ca6351e003826fULL,0x142929670a0e6e70ULL,
+            0x27b70a8546d22ffcULL,0x2e1b21385c26c926ULL,0x4d2c6dfc5ac42aedULL,0x53380d139d95b3dfULL,
+            0x650a73548baf63deULL,0x766a0abb3c77b2a8ULL,0x81c2c92e47edaee6ULL,0x92722c851482353bULL,
+            0xa2bfe8a14cf10364ULL,0xa81a664bbc423001ULL,0xc24b8b70d0f89791ULL,0xc76c51a30654be30ULL,
+            0xd192e819d6ef5218ULL,0xd69906245565a910ULL,0xf40e35855771202aULL,0x106aa07032bbd1b8ULL,
+            0x19a4c116b8d2d0c8ULL,0x1e376c085141ab53ULL,0x2748774cdf8eeb99ULL,0x34b0bcb5e19b48a8ULL,
+            0x391c0cb3c5c95a63ULL,0x4ed8aa4ae3418acbULL,0x5b9cca4f7763e373ULL,0x682e6ff3d6b2b8a3ULL,
+            0x748f82ee5defb2fcULL,0x78a5636f43172f60ULL,0x84c87814a1f0ab72ULL,0x8cc702081a6439ecULL,
+            0x90befffa23631e28ULL,0xa4506cebde82bde9ULL,0xbef9a3f7b2c67915ULL,0xc67178f2e372532bULL,
+            0xca273eceea26619cULL,0xd186b8c721c0c207ULL,0xeada7dd6cde0eb1eULL,0xf57d4f7fee6ed178ULL,
+            0x06f067aa72176fbaULL,0x0a637dc5a2c898a6ULL,0x113f9804bef90daeULL,0x1b710b35131c471bULL,
+            0x28db77f523047d84ULL,0x32caab7b40c72493ULL,0x3c9ebe0a15c9bebcULL,0x431d67c49c100d4cULL,
+            0x4cc5d4becb3e42b6ULL,0x597f299cfc657e2aULL,0x5fcb6fab3ad6faecULL,0x6c44198c4a475817ULL
+        };
+        uint64_t w[80];
+        for (int i = 0; i < 16; i++)
+            w[i] = ((uint64_t)block[i*8]<<56) | ((uint64_t)block[i*8+1]<<48) |
+                   ((uint64_t)block[i*8+2]<<40) | ((uint64_t)block[i*8+3]<<32) |
+                   ((uint64_t)block[i*8+4]<<24) | ((uint64_t)block[i*8+5]<<16) |
+                   ((uint64_t)block[i*8+6]<<8) | (uint64_t)block[i*8+7];
+        for (int i = 16; i < 80; i++)
+            w[i] = sigma1(w[i-2]) + w[i-7] + sigma0(w[i-15]) + w[i-16];
+
+        uint64_t a=m_h[0], b=m_h[1], c=m_h[2], d=m_h[3];
+        uint64_t e=m_h[4], f=m_h[5], g=m_h[6], h=m_h[7];
+        for (int i = 0; i < 80; i++) {
+            uint64_t t1 = h + Sigma1(e) + Ch(e,f,g) + K[i] + w[i];
+            uint64_t t2 = Sigma0(a) + Maj(a,b,c);
+            h=g; g=f; f=e; e=d+t1; d=c; c=b; b=a; a=t1+t2;
+        }
+        m_h[0]+=a; m_h[1]+=b; m_h[2]+=c; m_h[3]+=d;
+        m_h[4]+=e; m_h[5]+=f; m_h[6]+=g; m_h[7]+=h;
+    }
+
+    uint64_t m_h[8];
+    unsigned char m_buf[BLOCK_SIZE];
+    size_t m_bufLen;
+    uint64_t m_totalLen;
+};
+
+class SHA384 : public SHA512Base {
+public:
+    static constexpr unsigned DIGEST_SIZE = 48;
+
+    SHA384() { reset(); }
+
+    void reset() {
+        static const uint64_t IV[8] = {
+            0xcbbb9d5dc1059ed8ULL, 0x629a292a367cd507ULL,
+            0x9159015a3070dd17ULL, 0x152fecd8f70e5939ULL,
+            0x67332667ffc00b31ULL, 0x8eb44a8768581511ULL,
+            0xdb0c2e0d64f98fa7ULL, 0x47b5481dbefa4fa4ULL
+        };
+        initState(IV);
+    }
+
+    void final(unsigned char digest[DIGEST_SIZE]) {
+        finalImpl(digest, DIGEST_SIZE);
+    }
+
+    static void hash(const unsigned char* data, size_t len, unsigned char digest[DIGEST_SIZE]) {
+        SHA384 ctx;
+        ctx.update(data, len);
+        ctx.final(digest);
+    }
+};
+
+class SHA512 : public SHA512Base {
+public:
+    static constexpr unsigned DIGEST_SIZE = 64;
+
+    SHA512() { reset(); }
+
+    void reset() {
+        static const uint64_t IV[8] = {
+            0x6a09e667f3bcc908ULL, 0xbb67ae8584caa73bULL,
+            0x3c6ef372fe94f82bULL, 0xa54ff53a5f1d36f1ULL,
+            0x510e527fade682d1ULL, 0x9b05688c2b3e6c1fULL,
+            0x1f83d9abfb41bd6bULL, 0x5be0cd19137e2179ULL
+        };
+        initState(IV);
+    }
+
+    void final(unsigned char digest[DIGEST_SIZE]) {
+        finalImpl(digest, DIGEST_SIZE);
+    }
+
+    static void hash(const unsigned char* data, size_t len, unsigned char digest[DIGEST_SIZE]) {
+        SHA512 ctx;
+        ctx.update(data, len);
+        ctx.final(digest);
+    }
+};
+
+#endif // _PODOFO_SHA_H_

--- a/src/podofo/main/PdfEncrypt.cpp
+++ b/src/podofo/main/PdfEncrypt.cpp
@@ -8,6 +8,7 @@
 #include "PdfFilter.h"
 
 #include <podofo/auxiliary/AES.h>
+#include <podofo/auxiliary/SHA.h>
 
 #include <boost/uuid/detail/md5.hpp>
 #include <boost/algorithm/hex.hpp>
@@ -21,19 +22,12 @@ using boost::uuids::detail::md5;
 using namespace std;
 using namespace PoDoFo;
 
-#ifdef PODOFO_HAVE_LIBIDN
 PdfEncryptAlgorithm PdfEncrypt::s_EnabledEncryptionAlgorithms =
 PdfEncryptAlgorithm::RC4V1 |
 PdfEncryptAlgorithm::RC4V2 |
 PdfEncryptAlgorithm::AESV2 |
 PdfEncryptAlgorithm::AESV3 |
 PdfEncryptAlgorithm::AESV3R6;
-#else // PODOFO_HAVE_LIBIDN
-PdfEncryptAlgorithm PdfEncrypt::s_EnabledEncryptionAlgorithms =
-PdfEncryptAlgorithm::RC4V1 |
-PdfEncryptAlgorithm::RC4V2 |
-PdfEncryptAlgorithm::AESV2;
-#endif // PODOFO_HAVE_LIBIDN
 
 #define AES_IV_LENGTH 16
 #define AES_BLOCK_SIZE 16
@@ -201,13 +195,11 @@ protected:
                     m_aes = AES(AESKeyLength::AES_128);
                     break;
                 }
-#ifdef PODOFO_HAVE_LIBIDN
                 case (size_t)PdfKeyLength::L256 / 8:
                 {
                     m_aes = AES(AESKeyLength::AES_256);
                     break;
                 }
-#endif
                 default:
                     PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InternalLogic, "Invalid AES key length");
             }
@@ -354,7 +346,6 @@ std::unique_ptr<PdfEncrypt> PoDoFo::PdfEncrypt::CreateFromObject(const PdfObject
         {
             return unique_ptr<PdfEncrypt>(new PdfEncryptAESV2(oValue, uValue, pValue, encryptMetadata));
         }
-#ifdef PODOFO_HAVE_LIBIDN
         else if ((lV == 5) && (
             (rValue == 5 && PdfEncrypt::IsEncryptionEnabled(PdfEncryptAlgorithm::AESV3))
             || (rValue == 6 && PdfEncrypt::IsEncryptionEnabled(PdfEncryptAlgorithm::AESV3R6))))
@@ -366,7 +357,6 @@ std::unique_ptr<PdfEncrypt> PoDoFo::PdfEncrypt::CreateFromObject(const PdfObject
             return unique_ptr<PdfEncrypt>(new PdfEncryptAESV3(oValue, oeValue, uValue,
                 ueValue, pValue, permsValue, (PdfAESV3Revision)rValue));
         }
-#endif // PODOFO_HAVE_LIBIDN
         else
         {
             PODOFO_RAISE_ERROR_INFO(PdfErrorCode::UnsupportedFilter, "Unsupported encryption method Version={} Revision={}", lV , rValue);
@@ -385,11 +375,9 @@ std::unique_ptr<PdfEncrypt> PoDoFo::PdfEncrypt::CreateFromEncrypt(const PdfEncry
             return unique_ptr<PdfEncrypt>(new PdfEncryptRC4(rhs));
         case PdfEncryptAlgorithm::AESV2:
             return unique_ptr<PdfEncrypt>(new PdfEncryptAESV2(rhs));
-#ifdef PODOFO_HAVE_LIBIDN
         case PdfEncryptAlgorithm::AESV3:
         case PdfEncryptAlgorithm::AESV3R6:
             return unique_ptr<PdfEncrypt>(new PdfEncryptAESV3(rhs));
-#endif // PODOFO_HAVE_LIBIDN
         default:
             PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InvalidEnumValue, "Invalid algorithm");
     }
@@ -543,57 +531,206 @@ bool PoDoFo::PdfEncrypt::CheckKey(unsigned char key1[32], unsigned char key2[32]
     return success;
 }
 
-#ifdef PODOFO_HAVE_LIBIDN
-
 PoDoFo::PdfEncryptSHABase::PdfEncryptSHABase()
+    : m_ueValue{ }, m_oeValue{ }, m_permsValue{ }
 {
 }
 
-PoDoFo::PdfEncryptSHABase::PdfEncryptSHABase(const PdfEncrypt &rhs)
+PoDoFo::PdfEncryptSHABase::PdfEncryptSHABase(const PdfEncrypt &rhs) : PdfEncrypt(rhs)
 {
+    const PdfEncrypt* ptr = &rhs;
+    std::memcpy(m_uValue, rhs.GetUValue(), sizeof(unsigned char) * 48);
+    std::memcpy(m_oValue, rhs.GetOValue(), sizeof(unsigned char) * 48);
+    std::memcpy(m_encryptionKey, rhs.GetEncryptionKey(), sizeof(unsigned char) * 32);
+    std::memcpy(m_permsValue, static_cast<const PdfEncryptSHABase*>(ptr)->m_permsValue, sizeof(unsigned char) * 16);
+    std::memcpy(m_ueValue, static_cast<const PdfEncryptSHABase*>(ptr)->m_ueValue, sizeof(unsigned char) * 32);
+    std::memcpy(m_oeValue, static_cast<const PdfEncryptSHABase*>(ptr)->m_oeValue, sizeof(unsigned char) * 32);
 }
 
 void PoDoFo::PdfEncryptSHABase::CreateEncryptionDictionary(PdfDictionary &dictionary) const
 {
-    PODOFO_RAISE_ERROR(PdfErrorCode::UnsupportedEncryptedFile);
+    dictionary.AddKey(PdfName::KeyFilter, PdfName("Standard"));
+
+    PdfDictionary cf;
+    PdfDictionary stdCf;
+
+    dictionary.AddKey("V", static_cast<int64_t>(5));
+    dictionary.AddKey("R", static_cast<int64_t>(m_rValue));
+    dictionary.AddKey("Length", static_cast<int64_t>(256));
+
+    stdCf.AddKey("CFM", PdfName("AESV3"));
+    stdCf.AddKey("Length", static_cast<int64_t>(32));
+
+    dictionary.AddKey("O", PdfString::FromRaw({ reinterpret_cast<const char*>(this->GetOValue()), 48 }));
+    dictionary.AddKey("OE", PdfString::FromRaw({ reinterpret_cast<const char*>(this->GetOEValue()), 32 }));
+    dictionary.AddKey("U", PdfString::FromRaw({ reinterpret_cast<const char*>(this->GetUValue()), 48 }));
+    dictionary.AddKey("UE", PdfString::FromRaw({ reinterpret_cast<const char*>(this->GetUEValue()), 32 }));
+    dictionary.AddKey("Perms", PdfString::FromRaw({ reinterpret_cast<const char*>(this->GetPermsValue()), 16 }));
+
+    stdCf.AddKey("AuthEvent", PdfName("DocOpen"));
+    cf.AddKey("StdCF", stdCf);
+
+    dictionary.AddKey("CF", cf);
+    dictionary.AddKey("StrF", PdfName("StdCF"));
+    dictionary.AddKey("StmF", PdfName("StdCF"));
+
+    dictionary.AddKey("P", PdfVariant(static_cast<int64_t>(this->GetPValue())));
 }
 
 bool PoDoFo::PdfEncryptSHABase::Authenticate(const std::string_view &documentID, const std::string_view &password, const bufferview &uValue, const std::string_view &ueValue, const bufferview &oValue, const std::string_view &oeValue, PdfPermissions pValue, const std::string_view &permsValue, int lengthValue, int rValue)
 {
-    PODOFO_RAISE_ERROR(PdfErrorCode::UnsupportedEncryptedFile);
+    m_pValue = pValue;
+    m_keyLength = lengthValue / 8;
+    m_rValue = rValue;
+
+    std::memcpy(m_uValue, uValue.data(), 48);
+    std::memcpy(m_ueValue, ueValue.data(), 32);
+    std::memcpy(m_oValue, oValue.data(), 48);
+    std::memcpy(m_oeValue, oeValue.data(), 32);
+    std::memcpy(m_permsValue, permsValue.data(), 16);
+
+    return Authenticate(password, documentID);
 }
 
 void PoDoFo::PdfEncryptSHABase::GenerateInitialVector(unsigned char iv[]) const
 {
-    PODOFO_RAISE_ERROR(PdfErrorCode::UnsupportedEncryptedFile);
+    for (unsigned i = 0; i < AES_IV_LENGTH; i++)
+        iv[i] = rand() % 255;
 }
 
 void PoDoFo::PdfEncryptSHABase::ComputeEncryptionKey()
 {
-    PODOFO_RAISE_ERROR(PdfErrorCode::UnsupportedEncryptedFile);
+    srand((unsigned)time(nullptr));
+    for (unsigned i = 0; i < m_keyLength; i++)
+        m_encryptionKey[i] = rand() % 255;
 }
 
 void PoDoFo::PdfEncryptSHABase::ComputeHash(const unsigned char *pswd, unsigned pswdLen, unsigned char salt[8], unsigned char uValue[48], unsigned char hashValue[32])
 {
-    PODOFO_RAISE_ERROR(PdfErrorCode::UnsupportedEncryptedFile);
+    PODOFO_ASSERT(pswdLen <= 127);
+
+    // Initial SHA-256 hash: password + salt + uValue(optional)
+    SHA256 sha256;
+    if (pswdLen != 0)
+        sha256.update(pswd, pswdLen);
+    sha256.update(salt, 8);
+    if (uValue != nullptr)
+        sha256.update(uValue, 48);
+    sha256.final(hashValue);
+
+    if (m_rValue > 5) // R6: extended hash algorithm per PDF 2.0
+    {
+        unsigned dataLen = 0;
+        unsigned blockLen = 32;
+        unsigned char data[(127 + 64 + 48) * 64];
+        unsigned char block[64];
+        std::memcpy(block, hashValue, 32);
+
+        for (unsigned i = 0; i < 64 || i < (unsigned)(32 + data[dataLen - 1]); i++)
+        {
+            dataLen = pswdLen + blockLen;
+            std::memcpy(data, pswd, pswdLen);
+            std::memcpy(data + pswdLen, block, blockLen);
+            if (uValue)
+            {
+                std::memcpy(data + dataLen, uValue, 48);
+                dataLen += 48;
+            }
+            for (unsigned j = 1; j < 64; j++)
+                std::memcpy(data + j * dataLen, data, dataLen);
+
+            unsigned totalDataLen = dataLen * 64;
+
+            // AES-128-CBC encrypt with key=block[0..15], iv=block[16..31]
+            AES aes(AESKeyLength::AES_128);
+            unsigned char *encrypted = aes.EncryptCBC(data, totalDataLen, block, block + 16);
+            std::memcpy(data, encrypted, totalDataLen);
+            dataLen = totalDataLen;
+            delete[] encrypted;
+
+            unsigned sum = 0;
+            for (unsigned j = 0; j < 16; j++)
+                sum += data[j];
+            blockLen = 32 + (sum % 3) * 16;
+
+            if (blockLen == 32)
+            {
+                SHA256::hash(data, dataLen, block);
+            }
+            else if (blockLen == 48)
+            {
+                SHA384::hash(data, dataLen, block);
+            }
+            else
+            {
+                SHA512::hash(data, dataLen, block);
+            }
+        }
+        std::memcpy(hashValue, block, 32);
+    }
 }
 
 void PoDoFo::PdfEncryptSHABase::ComputeUserKey(const unsigned char *userpswd, unsigned len)
 {
-    PODOFO_RAISE_ERROR(PdfErrorCode::UnsupportedEncryptedFile);
+    // Generate User Salts
+    unsigned char vSalt[8];
+    unsigned char kSalt[8];
+    for (unsigned i = 0; i < 8; i++)
+    {
+        vSalt[i] = rand() % 255;
+        kSalt[i] = rand() % 255;
+    }
+
+    unsigned char hashValue[32];
+    ComputeHash(userpswd, len, vSalt, 0, hashValue);
+
+    std::memcpy(m_uValue, hashValue, 32);
+    std::memcpy(m_uValue + 32, vSalt, 8);
+    std::memcpy(m_uValue + 32 + 8, kSalt, 8);
+
+    // UE = AES-256 encrypted file encryption key
+    ComputeHash(userpswd, len, kSalt, 0, hashValue);
+    unsigned char iv[AES_IV_LENGTH];
+    std::memset(iv, 0, AES_IV_LENGTH);
+    AES aes(AESKeyLength::AES_256);
+    unsigned char *encrypted = aes.EncryptCBC(m_encryptionKey, m_keyLength, hashValue, iv);
+    std::memcpy(m_ueValue, encrypted, 32);
+    delete[] encrypted;
 }
 
-void PoDoFo::PdfEncryptSHABase::ComputeOwnerKey(const unsigned char *userpswd, unsigned len)
+void PoDoFo::PdfEncryptSHABase::ComputeOwnerKey(const unsigned char *ownerpswd, unsigned len)
 {
-    PODOFO_RAISE_ERROR(PdfErrorCode::UnsupportedEncryptedFile);
+    unsigned char vSalt[8];
+    unsigned char kSalt[8];
+    for (unsigned i = 0; i < 8; i++)
+    {
+        vSalt[i] = rand() % 255;
+        kSalt[i] = rand() % 255;
+    }
+
+    unsigned char hashValue[32];
+    ComputeHash(ownerpswd, len, vSalt, m_uValue, hashValue);
+
+    std::memcpy(m_oValue, hashValue, 32);
+    std::memcpy(m_oValue + 32, vSalt, 8);
+    std::memcpy(m_oValue + 32 + 8, kSalt, 8);
+
+    ComputeHash(ownerpswd, len, kSalt, m_uValue, hashValue);
+    unsigned char iv[AES_IV_LENGTH];
+    std::memset(iv, 0, AES_IV_LENGTH);
+    AES aes(AESKeyLength::AES_256);
+    unsigned char *encrypted = aes.EncryptCBC(m_encryptionKey, m_keyLength, hashValue, iv);
+    std::memcpy(m_oeValue, encrypted, 32);
+    delete[] encrypted;
 }
 
 void PoDoFo::PdfEncryptSHABase::PreprocessPassword(const std::string_view &password, unsigned char *outBuf, unsigned &len)
 {
-    PODOFO_RAISE_ERROR(PdfErrorCode::UnsupportedEncryptedFile);
+    // Simplified SASLprep: just truncate to 127 bytes
+    size_t l = password.size();
+    len = l > 127 ? 127 : (unsigned)l;
+    std::memcpy(outBuf, password.data(), len);
 }
-
-#endif // PODOFO_HAVE_LIBIDN
 
 PoDoFo::PdfEncryptAESBase::~PdfEncryptAESBase()
 {
@@ -609,7 +746,7 @@ void PoDoFo::PdfEncryptAESBase::BaseDecrypt(const unsigned char *key, unsigned k
 {
     DUMP_API_CALL
 
-    AES aes(AESKeyLength::AES_128);
+    AES aes(keylen == (unsigned)((int)PdfKeyLength::L256 / 8) ? AESKeyLength::AES_256 : AESKeyLength::AES_128);
     unsigned char *tmp = aes.DecryptCBC(textin, textlen, key, iv);
     uint8_t paddingLen = tmp[textlen - 1];
     textoutlen = textlen - paddingLen;
@@ -621,14 +758,12 @@ void PoDoFo::PdfEncryptAESBase::BaseEncrypt(const unsigned char *key, unsigned k
 {
     DUMP_API_CALL
     (void)textoutlen;
-    
+
     AES aes;
     if (keyLen == (int)PdfKeyLength::L128 / 8)
         aes = AES(AESKeyLength::AES_128);
-#ifdef PODOFO_HAVE_LIBIDN
     else if (keyLen == (int)PdfKeyLength::L256 / 8)
         aes = AES(AESKeyLength::AES_256);
-#endif
     else
         PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InternalLogic, "Invalid AES key length");
 
@@ -1251,61 +1386,205 @@ bool PoDoFo::PdfEncryptAESV2::Authenticate(const std::string_view &password, con
     return success;
 }
 
-#ifdef PODOFO_HAVE_LIBIDN
-
 PoDoFo::PdfEncryptAESV3::PdfEncryptAESV3(PdfString oValue, PdfString oeValue, PdfString uValue, PdfString ueValue, PdfPermissions pValue, PdfString permsValue, PdfAESV3Revision rev)
+    : PdfEncryptAESBase()
 {
+    m_pValue = pValue;
+    m_Algorithm = rev == PdfAESV3Revision::R6 ? PdfEncryptAlgorithm::AESV3R6 : PdfEncryptAlgorithm::AESV3;
+
+    m_eKeyLength = PdfKeyLength::L256;
+    m_keyLength = (int)PdfKeyLength::L256 / 8;
+    m_rValue = (int)rev;
+
+    auto& oValueData = oValue.GetRawData();
+    if (oValueData.size() < 48)
+        PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InvalidEncryptionDict, "/O value is invalid");
+
+    auto& oeValueData = oeValue.GetRawData();
+    if (oeValueData.size() < 32)
+        PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InvalidEncryptionDict, "/OE value is invalid");
+
+    auto& uValueData = uValue.GetRawData();
+    if (uValueData.size() < 48)
+        PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InvalidEncryptionDict, "/U value is invalid");
+
+    auto& ueValueData = ueValue.GetRawData();
+    if (ueValueData.size() < 32)
+        PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InvalidEncryptionDict, "/UE value is invalid");
+
+    auto& permsValueData = permsValue.GetRawData();
+    if (permsValueData.size() < 16)
+        PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InvalidEncryptionDict, "/Perms value is invalid");
+
+    std::memcpy(m_oValue, oValueData.data(), 48);
+    std::memcpy(m_oeValue, oeValueData.data(), 32);
+    std::memcpy(m_uValue, uValueData.data(), 48);
+    std::memcpy(m_ueValue, ueValueData.data(), 32);
+    std::memcpy(m_permsValue, permsValueData.data(), 16);
+    std::memset(m_encryptionKey, 0, 32);
 }
 
 PoDoFo::PdfEncryptAESV3::PdfEncryptAESV3(const std::string_view &userPassword, const std::string_view &ownerPassword, PdfAESV3Revision rev, PdfPermissions protection)
+    : PdfEncryptAESBase()
 {
+    m_userPass = userPassword;
+    m_ownerPass = ownerPassword;
+    m_Algorithm = rev == PdfAESV3Revision::R6 ? PdfEncryptAlgorithm::AESV3R6 : PdfEncryptAlgorithm::AESV3;
+
+    m_rValue = (int)rev;
+    m_eKeyLength = PdfKeyLength::L256;
+    m_keyLength = (int)PdfKeyLength::L256 / 8;
+
+    std::memset(m_oValue, 0, 48);
+    std::memset(m_uValue, 0, 48);
+    std::memset(m_encryptionKey, 0, 32);
+    std::memset(m_ueValue, 0, 32);
+    std::memset(m_oeValue, 0, 32);
+
+    m_pValue = PdfPermissions::Default | protection;
 }
 
 PoDoFo::PdfEncryptAESV3::PdfEncryptAESV3(const PdfEncrypt &rhs)
-{
-}
+    : PdfEncryptSHABase(rhs) {}
 
 std::unique_ptr<InputStream> PoDoFo::PdfEncryptAESV3::CreateEncryptionInputStream(InputStream &inputStream, size_t inputLen, const PdfReference &objref)
 {
-    PODOFO_RAISE_ERROR(PdfErrorCode::UnsupportedEncryptedFile);
+    (void)objref;
+    return unique_ptr<InputStream>(new PdfAESInputStream(inputStream, inputLen, m_encryptionKey, 32));
 }
 
 std::unique_ptr<OutputStream> PoDoFo::PdfEncryptAESV3::CreateEncryptionOutputStream(OutputStream &outputStream, const PdfReference &objref)
 {
-    PODOFO_RAISE_ERROR(PdfErrorCode::UnsupportedEncryptedFile);
+    (void)outputStream;
+    (void)objref;
+    PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InternalLogic, "CreateEncryptionOutputStream does not yet support AESV3");
 }
 
 void PoDoFo::PdfEncryptAESV3::Encrypt(const char *inStr, size_t inLen, const PdfReference &objref, char *outStr, size_t outLen) const
 {
-    PODOFO_RAISE_ERROR(PdfErrorCode::UnsupportedEncryptedFile);
+    (void)objref;
+    size_t offset = CalculateStreamOffset();
+    this->GenerateInitialVector((unsigned char*)outStr);
+    this->BaseEncrypt(m_encryptionKey, m_keyLength, (unsigned char*)outStr, (const unsigned char*)inStr, inLen, (unsigned char*)outStr + offset, outLen - offset);
 }
 
 void PoDoFo::PdfEncryptAESV3::Decrypt(const char *inStr, size_t inLen, const PdfReference &objref, char *outStr, size_t &outLen) const
 {
-    PODOFO_RAISE_ERROR(PdfErrorCode::UnsupportedEncryptedFile);
+    (void)objref;
+    size_t offset = CalculateStreamOffset();
+    if (inLen <= offset)
+    {
+        outLen = 0;
+        return;
+    }
+    this->BaseDecrypt(const_cast<unsigned char*>(m_encryptionKey), m_keyLength, (const unsigned char*)inStr, (const unsigned char*)inStr + offset, inLen - offset, (unsigned char*)outStr, outLen);
 }
 
 size_t PoDoFo::PdfEncryptAESV3::CalculateStreamOffset() const
 {
-    PODOFO_RAISE_ERROR(PdfErrorCode::UnsupportedEncryptedFile);
+    return AES_IV_LENGTH;
 }
 
 size_t PoDoFo::PdfEncryptAESV3::CalculateStreamLength(size_t length) const
 {
-    PODOFO_RAISE_ERROR(PdfErrorCode::UnsupportedEncryptedFile);
+    size_t realLength = ((length + 15) & ~15) + AES_IV_LENGTH;
+    if (length % 16 == 0)
+        realLength += 16;
+    return realLength;
 }
 
 bool PoDoFo::PdfEncryptAESV3::Authenticate(const std::string_view &password, const std::string_view &documentId)
 {
-    PODOFO_RAISE_ERROR(PdfErrorCode::UnsupportedEncryptedFile);
+    (void)documentId;
+    bool success = false;
+
+    unsigned char pswd_sasl[127];
+    unsigned pswdLen;
+    PreprocessPassword(password, pswd_sasl, pswdLen);
+
+    // Test 1: is it the user key?
+    unsigned char hashValue[32];
+    ComputeHash(pswd_sasl, pswdLen, m_uValue + 32, 0, hashValue); // user Validation Salt
+
+    success = CheckKey(hashValue, m_uValue);
+    if (!success)
+    {
+        // Test 2: is it the owner key?
+        ComputeHash(pswd_sasl, pswdLen, m_oValue + 32, m_uValue, hashValue); // owner Validation Salt
+        success = CheckKey(hashValue, m_oValue);
+
+        if (success)
+        {
+            m_ownerPass = password;
+            ComputeHash(pswd_sasl, pswdLen, m_oValue + 40, m_uValue, hashValue); // owner Key Salt
+
+            // Decrypt OE to get file encryption key
+            unsigned char iv[AES_IV_LENGTH];
+            std::memset(iv, 0, AES_IV_LENGTH);
+            AES aes(AESKeyLength::AES_256);
+            unsigned char *decrypted = aes.DecryptCBC(m_oeValue, 32, hashValue, iv);
+            std::memcpy(m_encryptionKey, decrypted, 32);
+            delete[] decrypted;
+        }
+    }
+    else
+    {
+        m_userPass = password;
+        ComputeHash(pswd_sasl, pswdLen, m_uValue + 40, 0, hashValue); // user Key Salt
+
+        // Decrypt UE to get file encryption key
+        unsigned char iv[AES_IV_LENGTH];
+        std::memset(iv, 0, AES_IV_LENGTH);
+        AES aes(AESKeyLength::AES_256);
+        unsigned char *decrypted = aes.DecryptCBC(m_ueValue, 32, hashValue, iv);
+        std::memcpy(m_encryptionKey, decrypted, 32);
+        delete[] decrypted;
+    }
+
+    return success;
 }
 
 void PoDoFo::PdfEncryptAESV3::GenerateEncryptionKey(const std::string_view &documentId)
 {
-    PODOFO_RAISE_ERROR(PdfErrorCode::UnsupportedEncryptedFile);
-}
+    (void)documentId;
 
-#endif // PODOFO_HAVE_LIBIDN
+    unsigned char userpswd[127];
+    unsigned char ownerpswd[127];
+    unsigned userpswdLen;
+    unsigned ownerpswdLen;
+    PreprocessPassword(m_userPass, userpswd, userpswdLen);
+    PreprocessPassword(m_ownerPass, ownerpswd, ownerpswdLen);
+
+    ComputeEncryptionKey();
+    ComputeUserKey(userpswd, userpswdLen);
+    ComputeOwnerKey(ownerpswd, ownerpswdLen);
+
+    // Compute Perms value
+    unsigned char perms[16];
+    perms[3] = ((unsigned)m_pValue >> 24) & 0xFF;
+    perms[2] = ((unsigned)m_pValue >> 16) & 0xFF;
+    perms[1] = ((unsigned)m_pValue >> 8) & 0xFF;
+    perms[0] = ((unsigned)m_pValue >> 0) & 0xFF;
+    perms[4] = 0xFF;
+    perms[5] = 0xFF;
+    perms[6] = 0xFF;
+    perms[7] = 0xFF;
+    perms[8] = m_EncryptMetadata ? 'T' : 'F';
+    perms[9] = 'a';
+    perms[10] = 'd';
+    perms[11] = 'b';
+    perms[12] = 0;
+    perms[13] = 0;
+    perms[14] = 0;
+    perms[15] = 0;
+
+    unsigned char iv[AES_IV_LENGTH];
+    std::memset(iv, 0, AES_IV_LENGTH);
+    AES aes(AESKeyLength::AES_256);
+    unsigned char *encrypted = aes.EncryptCBC(perms, 16, m_encryptionKey, iv);
+    std::memcpy(m_permsValue, encrypted, 16);
+    delete[] encrypted;
+}
 
 PoDoFo::PdfEncryptRC4::PdfEncryptRC4(PdfString oValue, PdfString uValue, PdfPermissions pValue, int rValue, PdfEncryptAlgorithm algorithm, int length, bool encryptMetadata)
 {

--- a/src/podofo/main/PdfEncrypt.h
+++ b/src/podofo/main/PdfEncrypt.h
@@ -46,18 +46,14 @@ enum class PdfKeyLength
     L80 = 80,
     L96 = 96,
     L128 = 128,
-#ifdef PODOFO_HAVE_LIBIDN
     L256 = 256
-#endif //PODOFO_HAVE_LIBIDN
 };
 
-#ifdef PODOFO_HAVE_LIBIDN
 enum class PdfAESV3Revision
 {
     R5 = 5,
     R6 = 6,
 };
-#endif //PODOFO_HAVE_LIBIDN
 
 /** Set user permissions/restrictions on a document
  */
@@ -91,10 +87,8 @@ enum class PdfEncryptAlgorithm
     RC4V1 = 1,      ///< RC4 Version 1 encryption using a 40bit key
     RC4V2 = 2,      ///< RC4 Version 2 encryption using a key with 40-128bit
     AESV2 = 4,      ///< AES encryption with a 128 bit key (PDF1.6)
-#ifdef PODOFO_HAVE_LIBIDN
     AESV3 = 8,      ///< AES encryption with a 256 bit key (PDF1.7 extension 3) - Support added by P. Zent
     AESV3R6 = 16,   ///< AES encryption with a 256 bit key, Revision 6 (PDF1.7 extension 8, PDF 2.0)
-#endif //PODOFO_HAVE_LIBIDN
 };
 
 /** A class that is used to encrypt a PDF file and
@@ -403,8 +397,6 @@ private:
     static PdfEncryptAlgorithm s_EnabledEncryptionAlgorithms; // Or'ed int containing the enabled encryption algorithms
 };
 
-#ifdef PODOFO_HAVE_LIBIDN
-
 /** A pure virtual class that is used to encrypt a PDF file (AES-256)
  *  This class is the base for classes that implement algorithms based on SHA hashes
  *
@@ -464,15 +456,6 @@ protected:
     unsigned char m_oeValue[32];        // OE entry in pdf document
     unsigned char m_permsValue[16];     // Perms entry in pdf document
 };
-
-/** A pure virtual class that is used to encrypt a PDF file (RC4, AES-128)
- *  This class is the base for classes that implement algorithms based on MD5 hashes
- *
- *  Client code is working only with PdfEncrypt class and knows nothing
- *	about PdfEncrypt*, it is created through CreatePdfEncrypt factory method
- *
- */
-#endif // PODOFO_HAVE_LIBIDN
 
 /** A pure virtual class that is used to encrypt a PDF file (AES-128/256)
  *  This class is the base for classes that implement algorithms based on AES
@@ -612,8 +595,6 @@ protected:
     bool Authenticate(const std::string_view& password, const std::string_view& documentId) override;
 };
 
-#ifdef PODOFO_HAVE_LIBIDN
-
 /** A class that is used to encrypt a PDF file (AES-256)
  *
  *  Client code is working only with PdfEncrypt class and knows nothing
@@ -647,8 +628,6 @@ protected:
 
     void GenerateEncryptionKey(const std::string_view& documentId) override;
 };
-
-#endif // PODOFO_HAVE_LIBIDN
 
 /** A class that is used to encrypt a PDF file (RC4 40-bit and 128-bit)
  *


### PR DESCRIPTION
Implement AES-V3 encryption support using custom SHA-256/384/512 and existing AES implementations, removing the dependency on libidn (GPL) and OpenSSL.

- Add SHA-256, SHA-384, SHA-512 header-only implementation (SHA.h)
- Remove all #ifdef PODOFO_HAVE_LIBIDN guards
- Implement PdfEncryptSHABase methods (ComputeHash, Authenticate, etc.)
- Implement PdfEncryptAESV3 methods (Decrypt, Encrypt, key derivation)
- Support both R5 and R6 (PDF 2.0) encryption revisions
- Use simplified SASLprep (truncate to 127 bytes) instead of libidn