### PR TITLE
Expose local text matrix for extraction

### DIFF
--- a/src/podofo/main/PdfPage.h
+++ b/src/podofo/main/PdfPage.h
@@ -33,7 +33,8 @@ struct PdfTextEntry final
     double Y;
     double Length;
     nullable<Rect> BoundingBox;
-    double TextMatrix[6];
+    double TextMatrix[6];       // Combined T_m * CTM (page coordinates)
+    double LocalTextMatrix[6];  // T_m only (without CTM, for writing back)
     double FontSize;
     std::string FontName;
     double FontScale = 1;

--- a/src/podofo/main/PdfPage_TextExtraction.cpp
+++ b/src/podofo/main/PdfPage_TextExtraction.cpp
@@ -753,6 +753,7 @@ void addEntryChunk(vector<PdfTextEntry> &textEntries, StringChunkList &chunks, c
     {
         textEntries.push_back(PdfTextEntry{ str, pageIndex,
             strPosition.X, strPosition.Y, strLength, bbox,
+            {1.0, 0.0, 0.0, 1.0, 0.0, 0.0},
             {1.0, 0.0, 0.0, 1.0, 0.0, 0.0}, textState.PdfState.FontSize, textState.PdfState.Font->GetName(),
             textState.PdfState.FontScale, textState.PdfState.CharSpacing, textState.PdfState.WordSpacing,
             textState.PdfState.Font->GetStringLength(str, textState.PdfState),
@@ -769,6 +770,7 @@ void addEntryChunk(vector<PdfTextEntry> &textEntries, StringChunkList &chunks, c
         auto p_1 = rawp * (*rotation);
         textEntries.push_back(PdfTextEntry{ str, pageIndex,
             p_1.X, p_1.Y, strLength, bbox,
+            {1.0, 0.0, 0.0, 1.0, 0.0, 0.0},
             {1.0, 0.0, 0.0, 1.0, 0.0, 0.0}, textState.PdfState.FontSize, textState.PdfState.Font->GetName(),
             textState.PdfState.FontScale, textState.PdfState.CharSpacing, textState.PdfState.WordSpacing,
             textState.PdfState.Font->GetStringLength(str, textState.PdfState),
@@ -780,6 +782,7 @@ void addEntryChunk(vector<PdfTextEntry> &textEntries, StringChunkList &chunks, c
             }});
     }
     textState.T_rm.ToArray(textEntries.back().TextMatrix);
+    textState.T_m.ToArray(textEntries.back().LocalTextMatrix);
 
     chunks.clear();
 }


### PR DESCRIPTION
アプリ側でtextWidthを正常に取得できるようにするため、LocalTextMatrixをエクスポートする。