### PR TITLE
Fix Type1 font text extraction by using 1-byte CodeSpaceSize

### DIFF
--- a/src/podofo/main/PdfFontBuiltinEncoding.cpp
+++ b/src/podofo/main/PdfFontBuiltinEncoding.cpp
@@ -82,19 +82,22 @@ PdfEncodingMapConstPtr PdfFontMetrics::getFontType1Encoding(FT_Face face)
             if (found == unicodeMap.end())
             {
                 // Some symbol characters may have no unicode representation
-                codeMap.PushMapping(PdfCharCode((unsigned)pair.second), U'\0');
+                // Use CodeSpaceSize=1 because Type1 fonts always use 1-byte character codes
+                codeMap.PushMapping(PdfCharCode((unsigned)pair.second, 1), U'\0');
                 continue;
             }
 
-            codeMap.PushMapping(PdfCharCode((unsigned)pair.second), (char32_t)found->second);
+            // Use CodeSpaceSize=1 because Type1 fonts always use 1-byte character codes
+            codeMap.PushMapping(PdfCharCode((unsigned)pair.second, 1), (char32_t)found->second);
         }
     }
     else
     {
         // NOTE: Some very strange CCF fonts just supply an unicode map
         // For these, we just assume code identity with Unicode codepoint
+        // Use CodeSpaceSize=1 because Type1 fonts always use 1-byte character codes
         for (auto& pair : unicodeMap)
-            codeMap.PushMapping(PdfCharCode((unsigned)pair.second), (char32_t)pair.second);
+            codeMap.PushMapping(PdfCharCode((unsigned)pair.second, 1), (char32_t)pair.second);
     }
 
     return PdfEncodingMapConstPtr(new PdfFontBuiltinType1Encoding(std::move(codeMap)));


### PR DESCRIPTION
The PdfCharCode 1-arg constructor was hardcoded to CodeSpaceSize=2 (for Japanese CID font writing support), but Type1 fonts always use 1-byte character codes (0-255). This caused the text scanner to read 2 bytes per character from the content stream, resulting in completely garbled text extraction for Type1 fonts without an explicit /Encoding entry (e.g., Computer Modern fonts from LaTeX).

Fix: explicitly pass CodeSpaceSize=1 when building the encoding map in getFontType1Encoding().