### PR TITLE
Fix/tex math font text extraction

### DIFF
--- a/src/podofo/main/PdfCharCodeMap.cpp
+++ b/src/podofo/main/PdfCharCodeMap.cpp
@@ -13,6 +13,9 @@
 using namespace std;
 using namespace PoDoFo;
 
+// Fixed seed used to shuffle the code point map entries before building the BST
+constexpr unsigned CPMapShuffleSeed = 5489;
+
 PdfCharCodeMap::PdfCharCodeMap()
     : m_MapDirty(false), m_codePointMapHead(nullptr), m_depth(0) { }
 
@@ -220,14 +223,19 @@ void PdfCharCodeMap::reviseCPMap()
         m_codePointMapHead = nullptr;
     }
 
-    // Randomize items in the map in a separate list
+    // Shuffle items in the map in a separate list
     // so BST creation will be more balanced
     // https://en.wikipedia.org/wiki/Random_binary_tree
+    // NOTE: The shuffle is seeded with a constant so the built tree, and hence
+    // the reverse lookups performed on it, are reproducible. A seed taken from
+    // std::random_device would make the code unit returned for a code point that
+    // is mapped by more than one code unit, and the string lengths computed from
+    // it, change at every run
     // TODO: Create a perfectly balanced BST
     vector<pair<PdfCharCode, vector<codepoint>>> pairs;
     pairs.reserve(m_CodeUnitMap.size());
     std::copy(m_CodeUnitMap.begin(), m_CodeUnitMap.end(), std::back_inserter(pairs));
-    std::mt19937 e(random_device{}());
+    std::mt19937 e(CPMapShuffleSeed);
     std::shuffle(pairs.begin(), pairs.end(), e);
 
     for (auto& pair : pairs)
@@ -248,8 +256,12 @@ void PdfCharCodeMap::reviseCPMap()
             curr = &found->Ligatures;
         }
 
-        // Finally set the char code on the last found/added node
-        found->CodeUnit = pair.first;
+        // Finally set the char code on the last found/added node. NOTE: When more
+        // than one code unit maps to the same code point(s), as it happens in fonts
+        // that have duplicated glyphs, keep the smallest code unit so the choice
+        // doesn't depend on the order the nodes are inserted with
+        if (found->CodeUnit.CodeSpaceSize == 0 || pair.first < found->CodeUnit)
+            found->CodeUnit = pair.first;
     }
 
     m_MapDirty = false;

--- a/src/podofo/main/PdfDifferenceEncoding.cpp
+++ b/src/podofo/main/PdfDifferenceEncoding.cpp
@@ -2732,6 +2732,16 @@ void PdfDifferenceEncoding::buildReverseMap()
         m_reverseMap[codePoints[0]] = (unsigned char)code;
     }
 
+    // Map the differences explicitly as well: they may define codes that fall
+    // outside of the code range of the base encoding, as it happens with the
+    // subsetted math fonts of (La)TeX, whose base encoding is built from the
+    // font program. They take precedence over the base encoding mappings
+    for (auto& difference : m_differences)
+    {
+        if (difference.MappedCodePoint != U'\0')
+            m_reverseMap[difference.MappedCodePoint] = difference.Code;
+    }
+
     m_reverseMapBuilt = true;
 }
 

--- a/src/podofo/main/PdfDifferenceEncoding.cpp
+++ b/src/podofo/main/PdfDifferenceEncoding.cpp
@@ -1328,6 +1328,90 @@ static struct
   { 0, nullptr }
 };
 
+// Glyph names used by the math fonts of the Computer Modern / Latin Modern
+// families (CMMI, CMSY, CMEX, LMMathItalic, LMMathSymbols, LMMathExtension, ...)
+// that (La)TeX embeds in PDFs. The /ToUnicode CMap of those fonts is typically
+// incomplete, so the glyph names of the /Encoding /Differences array are the only
+// way to recover part of their text, and most of those names are not in the AGL.
+// Reference: texglyphlist.txt of TeX Live (pdftex mapping)
+static struct
+{
+    char32_t u;
+    const char* name;
+} texNameToUnicodeTab[] = {
+    {0x0338, "negationslash"},
+    {0x0361, "tie"},
+    {0x03B5, "epsilon1"},
+    {0x03F0, "kappa1"},
+    {0x03F1, "rho1"},
+    {0x03D6, "pi1"},
+    {0x2016, "bardbl"},
+    {0x2032, "prime"},
+    {0x20D7, "vector"},
+    {0x2111, "Ifractur"},
+    {0x211C, "Rfractur"},
+    {0x2113, "lscript"},
+    {0x2195, "arrowbothv"},
+    {0x2196, "arrownorthwest"},
+    {0x2197, "arrownortheast"},
+    {0x2198, "arrowsoutheast"},
+    {0x2199, "arrowsouthwest"},
+    {0x21A6, "mapsto"},
+    {0x21A9, "arrowhookright"},
+    {0x21AA, "arrowhookleft"},
+    {0x21BC, "arrowlefttophalf"},
+    {0x21BD, "arrowleftbothalf"},
+    {0x21C0, "arrowrighttophalf"},
+    {0x21C1, "arrowrightbothalf"},
+    {0x21D5, "arrowdblbothv"},
+    {0x2210, "coproduct"},
+    {0x2213, "minusplus"},
+    {0x222E, "contintegral"},
+    {0x2240, "wreathproduct"},
+    {0x2243, "similarequal"},
+    {0x224D, "equivasymptotic"},
+    {0x226A, "lessmuch"},
+    {0x226B, "greatermuch"},
+    {0x227A, "precedes"},
+    {0x227B, "follows"},
+    {0x227C, "precedesequal"},
+    {0x227D, "followsequal"},
+    {0x2291, "subsetsqequal"},
+    {0x2292, "supersetsqequal"},
+    {0x2293, "intersectionsq"},
+    {0x2296, "circleminus"},
+    {0x2298, "circledivide"},
+    {0x2299, "circledot"},
+    {0x22A2, "turnstileleft"},
+    {0x22A3, "turnstileright"},
+    {0x22A4, "latticetop"},
+    {0x22C4, "diamondmath"},
+    {0x22C6, "star"},
+    {0x2308, "ceilingleft"},
+    {0x2309, "ceilingright"},
+    {0x230A, "floorleft"},
+    {0x230B, "floorright"},
+    {0x2322, "slurabove"},
+    {0x2323, "slurbelow"},
+    {0x25B3, "triangle"},
+    {0x25BD, "triangleinv"},
+    {0x266D, "flat"},
+    {0x266E, "natural"},
+    {0x266F, "sharp"},
+    {0x27E8, "angbracketleft"},
+    {0x27E9, "angbracketright"},
+    { 0, nullptr }
+};
+
+// Suffixes appended by the Computer Modern / Latin Modern math fonts to the name
+// of a base glyph to denote one of its bigger variants, for example
+// "summationdisplay" (the big summation sign of a displayed formula) or
+// "parenleftbig". They are stripped so that the base glyph name is looked up
+// instead
+static const char* texGlyphSizeSuffixes[] = {
+    "display", "text", "Bigg", "bigg", "Big", "big", nullptr
+};
+
 static struct {
     char32_t u;
     const char* name;
@@ -2656,12 +2740,45 @@ char32_t PdfDifferenceEncoding::NameToCodePoint(const PdfName& name)
     return NameToCodePoint((string_view)name.GetString());
 }
 
-char32_t PdfDifferenceEncoding::NameToCodePoint(const string_view& name)
+static char32_t lookupGlyphName(const string_view& name)
 {
     for (unsigned i = 0; nameToUnicodeTab[i].name != nullptr; i++)
     {
         if (nameToUnicodeTab[i].name == name)
             return nameToUnicodeTab[i].u;
+    }
+
+    for (unsigned i = 0; texNameToUnicodeTab[i].name != nullptr; i++)
+    {
+        if (texNameToUnicodeTab[i].name == name)
+            return texNameToUnicodeTab[i].u;
+    }
+
+    return U'\0';
+}
+
+char32_t PdfDifferenceEncoding::NameToCodePoint(const string_view& name)
+{
+    char32_t codePoint = lookupGlyphName(name);
+    if (codePoint != U'\0')
+        return codePoint;
+
+    // The math fonts of (La)TeX name the bigger variants of a glyph by appending a
+    // size suffix to the base glyph name, eg. "summationdisplay" for the big
+    // summation sign of a displayed formula. Such names are not in the AGL, so
+    // retry the lookup on the base glyph name
+    for (unsigned i = 0; texGlyphSizeSuffixes[i] != nullptr; i++)
+    {
+        string_view suffix(texGlyphSizeSuffixes[i]);
+        if (name.length() <= suffix.length()
+            || name.substr(name.length() - suffix.length()) != suffix)
+        {
+            continue;
+        }
+
+        codePoint = lookupGlyphName(name.substr(0, name.length() - suffix.length()));
+        if (codePoint != U'\0')
+            return codePoint;
     }
 
     // if we get here, then we might be looking up an undefined codepoint

--- a/src/podofo/main/PdfEncoding.cpp
+++ b/src/podofo/main/PdfEncoding.cpp
@@ -51,10 +51,13 @@ PdfEncoding::PdfEncoding(const PdfObject& fontObj, const PdfEncodingMapConstPtr&
     if (lastCharObj != nullptr)
         m_ParsedLimits.LastChar = PdfCharCode(static_cast<unsigned>(lastCharObj->GetNumber()));
 
-    if (m_ParsedLimits.LastChar.Code > m_ParsedLimits.FirstChar.Code)
+    if (m_ParsedLimits.LastChar.Code >= m_ParsedLimits.FirstChar.Code)
     {
         // If found valid /FirstChar and /LastChar, valorize
-        //  also the code size limits
+        //  also the code size limits. NOTE: /FirstChar and /LastChar are equal in
+        //  fonts that define a single character, as it happens with the subsetted
+        //  math fonts embedded by (La)TeX. Such limits are valid as well and are
+        //  needed to map the character code to its /Widths entry
         m_ParsedLimits.MinCodeSize = utls::GetCharCodeSize(m_ParsedLimits.FirstChar.Code);
         m_ParsedLimits.MaxCodeSize = utls::GetCharCodeSize(m_ParsedLimits.LastChar.Code);
     }

--- a/src/podofo/main/PdfEncoding.cpp
+++ b/src/podofo/main/PdfEncoding.cpp
@@ -711,7 +711,19 @@ bool PdfStringScanContext::TryScan(PdfCID& cid, string& utf8str, vector<codepoin
         success = false;
     }
 
-    if (m_toUnicode->TryGetCodePoints(cid.Unit, codepoints))
+    bool mapped = m_toUnicode->TryGetCodePoints(cid.Unit, codepoints);
+    if (!mapped && m_toUnicode != m_encoding
+        && m_encoding->GetType() == PdfEncodingMapType::Simple)
+    {
+        // A /ToUnicode CMap may be incomplete: for example the math fonts embedded
+        // by (La)TeX map only a few of the codes they actually use, leaving the big
+        // operators (such as the summation sign of a displayed formula) unmapped.
+        // For simple, one byte encodings the main /Encoding entry maps codes to
+        // glyph names, so it is a valid fallback to recover the missing code points
+        mapped = m_encoding->TryGetCodePoints(cid.Unit, codepoints);
+    }
+
+    if (mapped)
     {
         for (size_t i = 0; i < codepoints.size(); i++)
         {

--- a/src/podofo/main/PdfFont.cpp
+++ b/src/podofo/main/PdfFont.cpp
@@ -717,13 +717,19 @@ bool PdfFont::tryConvertToGIDs(const std::string_view& utf8Str, PdfGlyphAccess a
         auto end = utf8Str.end();
 
         auto& toUnicode = m_Encoding->GetToUnicodeMapSafe();
+        auto& encodingMap = m_Encoding->GetEncodingMap();
+        // The main /Encoding entry of a simple font maps codes to glyph names, so
+        // it can reverse map code points that an incomplete /ToUnicode CMap misses
+        bool tryEncodingMap = &encodingMap != &toUnicode
+            && encodingMap.GetType() == PdfEncodingMapType::Simple;
         while (it != end)
         {
             char32_t cp = utf8::next(it, end);
             PdfCharCode codeUnit;
             unsigned cid;
             unsigned gid;
-            if (toUnicode.TryGetCharCode(cp, codeUnit))
+            if (toUnicode.TryGetCharCode(cp, codeUnit)
+                || (tryEncodingMap && encodingMap.TryGetCharCode(cp, codeUnit)))
             {
                 if (m_Encoding->TryGetCIDId(codeUnit, cid))
                 {

--- a/src/podofo/main/PdfPage_TextExtraction.cpp
+++ b/src/podofo/main/PdfPage_TextExtraction.cpp
@@ -171,6 +171,8 @@ static void processChunks(const StringChunkList& chunks, string& destString,
     vector<GlyphAddress>& glyphAddresses);
 static double computeLength(const vector<const StatefulString*>& strings, const vector<GlyphAddress>& glyphAddresses,
     unsigned lowerIndex, unsigned upperIndex);
+static double computeStringLength(const vector<const StatefulString*>& strings,
+    const vector<GlyphAddress>& glyphAddresses, unsigned lowerIndex, unsigned upperIndex);
 static bool isMatchWholeWordSubstring(const string_view& str, const string_view& pattern, size_t& matchPos);
 static Rect computeBoundingBox(const TextState& textState, double boxWidth);
 static void read(const PdfVariantStack& stack, double &tx, double &ty);
@@ -743,6 +745,7 @@ void addEntryChunk(vector<PdfTextEntry> &textEntries, StringChunkList &chunks, c
     }
 
     double strLength = computeLength(strings, glyphAddresses, lowerIndex, upperIndexLimit - 1);
+    double stringLength = computeStringLength(strings, glyphAddresses, lowerIndex, upperIndexLimit - 1);
     nullable<Rect> bbox;
     if (options.ComputeBoundingBox)
         bbox = computeBoundingBox(textState, strLength);
@@ -756,7 +759,7 @@ void addEntryChunk(vector<PdfTextEntry> &textEntries, StringChunkList &chunks, c
             {1.0, 0.0, 0.0, 1.0, 0.0, 0.0},
             textState.PdfState.FontSize, textState.PdfState.Font->GetName(),
             textState.PdfState.FontScale, textState.PdfState.CharSpacing, textState.PdfState.WordSpacing,
-            textState.PdfState.Font->GetStringLength(str, textState.PdfState),
+            stringLength,
             textState.PdfState.Font->GetLineSpacing(textState.PdfState),
             {
                 {textState.PdfState.TextColor.GrayColor.Gray},
@@ -773,7 +776,7 @@ void addEntryChunk(vector<PdfTextEntry> &textEntries, StringChunkList &chunks, c
             {1.0, 0.0, 0.0, 1.0, 0.0, 0.0},
             textState.PdfState.FontSize, textState.PdfState.Font->GetName(),
             textState.PdfState.FontScale, textState.PdfState.CharSpacing, textState.PdfState.WordSpacing,
-            textState.PdfState.Font->GetStringLength(str, textState.PdfState),
+            stringLength,
             textState.PdfState.Font->GetLineSpacing(textState.PdfState),
             {
                 {textState.PdfState.TextColor.GrayColor.Gray},
@@ -1435,6 +1438,44 @@ double computeLength(const vector<const StatefulString*>& strings, const vector<
 
         return (fromPosition - toPosition).GetLength();
     }
+}
+
+// Measure the glyphs in the given range with the metrics of the font they were
+// drawn with. NOTE: An entry can span several strings, each one with its own
+// font, as it happens when a formula or a list bullet is drawn with a font of
+// its own: measuring the whole entry with the font of its first string would
+// account only for the few code points that font can map
+double computeStringLength(const vector<const StatefulString*>& strings,
+    const vector<GlyphAddress>& glyphAddresses, unsigned lowerIndex, unsigned upperIndex)
+{
+    PODOFO_ASSERT(lowerIndex <= upperIndex);
+    auto& fromAddr = glyphAddresses[lowerIndex];
+    auto& toAddr = glyphAddresses[upperIndex];
+    double length = 0;
+    for (unsigned i = fromAddr.StringIndex; i <= toAddr.StringIndex; i++)
+    {
+        auto str = strings[i];
+        if (str->State.PdfState.Font == nullptr || str->StringPositions.size() == 0)
+            continue;
+
+        unsigned glyphCount = (unsigned)str->StringPositions.size();
+        unsigned firstGlyph = i == fromAddr.StringIndex ? fromAddr.GlyphIndex : 0;
+        unsigned lastGlyph = i == toAddr.StringIndex ? toAddr.GlyphIndex : glyphCount - 1;
+        if (firstGlyph >= glyphCount || lastGlyph >= glyphCount || firstGlyph > lastGlyph)
+            continue;
+
+        unsigned begin = str->StringPositions[firstGlyph];
+        unsigned end = lastGlyph + 1 == glyphCount
+            ? (unsigned)str->String.size()
+            : str->StringPositions[lastGlyph + 1];
+        if (end <= begin)
+            continue;
+
+        length += str->State.PdfState.Font->GetStringLength(
+            string_view(str->String).substr(begin, end - begin), str->State.PdfState);
+    }
+
+    return length;
 }
 
 // Verify if the string matches the pattern and verify


### PR DESCRIPTION
Σ を抽出できるようにしました。原因は 2 段構えでした。

## 原因

`dinov2.pdf` P.5 の Σ は `/F51` = `QPXDOQ+LMMathExtension10-Regular` のコード 88 (`[(X)]TJ`) で描かれています。

1. **このフォントの `/ToUnicode` CMap が不完全** — 中身は `<30>`〜`<43>`(可変記号の部品) の 20 エントリだけで、コード 88 が入っていません。podofo は `PdfStringScanContext::TryScan()` で `/ToUnicode` しか見ないため、未定義コードは黙って捨てられていました (ailia 側ではなく podofo 側で欠落)。
2. **フォールバック先の情報も使えなかった** — `/Encoding /Differences` には `[88 /summationdisplay]` があるのに、`summationdisplay` は AGL に存在しないため `PdfDifferenceEncoding::NameToCodePoint()` が 0 を返します。

## 修正 (podofo サブモジュール、2 ファイル)

- [[PdfEncoding.cpp:714](https://claude.ai/epitaxy/podofo/src/podofo/main/PdfEncoding.cpp#L714)](podofo/src/podofo/main/PdfEncoding.cpp#L714) — `/ToUnicode` に該当コードが無い場合、1 バイト系 (`PdfEncodingMapType::Simple`) の主 `/Encoding` をフォールバックとして引く。`/ToUnicode` にマッピングがある文字の挙動は一切変わりません(上書きしない)。
- [[PdfDifferenceEncoding.cpp](https://claude.ai/epitaxy/podofo/src/podofo/main/PdfDifferenceEncoding.cpp#L1331)](podofo/src/podofo/main/PdfDifferenceEncoding.cpp#L1331) — TeX 数式フォント (CMEX/CMSY/CMMI, LMMath*) のグリフ名を追加。`display` / `text` / `big` / `Big` / `bigg` / `Bigg` のサイズ接尾辞を落として基底名で再検索する処理 (`summationdisplay` → `summation` → U+2211) と、AGL に無い TeX 名 61 個 (`lscript`, `bardbl`, `angbracketleft`, `ceilingleft`, `coproduct`, `circledot` など) のテーブルです。