### PR TITLE
Support the wide fields of a cross reference stream

### DIFF
--- a/src/podofo/main/PdfXRefStreamParserObject.h
+++ b/src/podofo/main/PdfXRefStreamParserObject.h
@@ -27,7 +27,10 @@ class PODOFO_API PdfXRefStreamParserObject final : public PdfParserObject
     friend class PdfParser;
 
     static constexpr unsigned W_ARRAY_SIZE = 3;
-    static constexpr unsigned W_MAX_BYTES = 4;
+    // The fields of an entry are read into an uint64_t, hence 8 bytes is the
+    // widest field that can be represented. NOTE: The PDF specification doesn't
+    // limit the widths, and writers do emit fields wider than 4 bytes
+    static constexpr unsigned W_MAX_BYTES = 8;
 
 private:
     /** Parse the object data from the given file handle starting at


### PR DESCRIPTION
The parser refused a cross reference stream whose /W array declares a field wider than 4 bytes, failing with PdfErrorCode::InvalidXRefStream and making the whole document unreadable. The PDF specification doesn't limit the width of the fields, and writers do emit wider ones: the incremental update of a-practical-guide-to-building-agents.pdf declares /W [1 5 1], hence a 5 bytes offset field, and the file could not be opened at all.

The fields are read into an uint64_t, so raise the limit to the 8 bytes that can be represented. The reading loop already reads exactly the declared number of bytes.